### PR TITLE
JSON format corrected

### DIFF
--- a/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/rest_controller/CurrencyExchangeController.java
+++ b/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/rest_controller/CurrencyExchangeController.java
@@ -2,7 +2,7 @@ package com.fake_orgasm.currency_exchange.rest_controller;
 
 import com.fake_orgasm.currency_exchange.models.DoubleMoney;
 import com.fake_orgasm.currency_exchange.services.MoneyExchanger;
-import org.json.simple.JSONObject;
+import org.json.simple.JSONArray;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,7 +44,7 @@ public class CurrencyExchangeController {
      * @return Process result.
      */
     @GetMapping("/bolivian")
-    public JSONObject getBolivianExchange(@RequestParam Double amount) {
+    public JSONArray getBolivianExchange(@RequestParam Double amount) {
         if (amount < 0 || amount > 1_000_000) {
             throw new RuntimeException("Amount must be greater than 0 and less than 1_000_000");
         }
@@ -59,7 +59,7 @@ public class CurrencyExchangeController {
      * @return Process result.
      */
     @GetMapping("/euro")
-    public JSONObject getEuroExchange(@RequestParam Double amount) {
+    public JSONArray getEuroExchange(@RequestParam Double amount) {
         if (amount < 0 || amount > 1_000_000) {
             throw new RuntimeException("Amount must be greater than 0 and less than 1_000_000");
         }
@@ -74,7 +74,7 @@ public class CurrencyExchangeController {
      * @return Process result.
      */
     @GetMapping("/dollar")
-    public JSONObject getDollarExchange(@RequestParam Double amount) {
+    public JSONArray getDollarExchange(@RequestParam Double amount) {
         if (amount < 0 || amount > 1_000_000) {
             throw new RuntimeException("Amount must be greater than 0 and less than 1_000_000");
         }

--- a/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/services/IMoneyExchanger.java
+++ b/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/services/IMoneyExchanger.java
@@ -1,6 +1,6 @@
 package com.fake_orgasm.currency_exchange.services;
 
-import org.json.simple.JSONObject;
+import org.json.simple.JSONArray;
 
 /**
  * Interface to establish promises of class' flow to obtain a result of processes.
@@ -15,5 +15,5 @@ public interface IMoneyExchanger<T> {
      * @param value Is value to be processed.
      * @return Json containing data processed.
      */
-    JSONObject getExchangeValues(T value);
+    JSONArray getExchangeValues(T value);
 }

--- a/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/services/MoneyExchanger.java
+++ b/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/services/MoneyExchanger.java
@@ -36,7 +36,7 @@ public class MoneyExchanger<T extends IMoneySubtracted<T>> implements IMoneyExch
     private final Map<T, Integer> exchangesMap;
 
     /**
-     * Integer to accumulate the total number of coins needed to execute the exchange
+     * Integer to accumulate the total number of coins needed to execute the exchange.
      */
     private int totalMoneyQuantity;
 

--- a/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/services/MoneyExchanger.java
+++ b/backend/money_exchange/src/main/java/com/fake_orgasm/currency_exchange/services/MoneyExchanger.java
@@ -4,6 +4,7 @@ import com.fake_orgasm.currency_exchange.libs.maxheap.MaxHeap;
 import com.fake_orgasm.currency_exchange.models.ExchangeRates;
 import com.fake_orgasm.currency_exchange.models.IMoneySubtracted;
 import java.util.*;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 /**
@@ -27,7 +28,7 @@ public class MoneyExchanger<T extends IMoneySubtracted<T>> implements IMoneyExch
     /**
      * A JsonObject to return to the final of the procurement.
      */
-    private final JSONObject jsonObject;
+    private final JSONArray jsonArray;
 
     /**
      * A Map to put all values with its exchange type.
@@ -42,7 +43,7 @@ public class MoneyExchanger<T extends IMoneySubtracted<T>> implements IMoneyExch
     public MoneyExchanger(ExchangeRates<T> moneyRates) {
         this.rates = moneyRates;
         this.heap = new MaxHeap<>(moneyRates.size());
-        this.jsonObject = new JSONObject();
+        this.jsonArray = new JSONArray();
         this.exchangesMap = new HashMap<>(moneyRates.size());
     }
 
@@ -61,15 +62,19 @@ public class MoneyExchanger<T extends IMoneySubtracted<T>> implements IMoneyExch
      * @param value Is money value to obtain all possible exchanges quantity.
      * @return A JsonObject with all values processed.
      */
-    public JSONObject getExchangeValues(T value) {
+    public JSONArray getExchangeValues(T value) {
         fillHeap();
         processQuantityRatesOnMap(value);
-        this.jsonObject.clear();
+        this.jsonArray.clear();
 
         for (T exchangeValue : exchangesMap.keySet()) {
-            jsonObject.put(String.valueOf(exchangeValue), exchangesMap.get(exchangeValue));
+            JSONObject moneyObject = new JSONObject();
+            JSONArray mappedArray = new JSONArray();
+            moneyObject.put("value", exchangeValue.toString());
+            moneyObject.put("quantity", exchangesMap.get(exchangeValue));
+            this.jsonArray.add(moneyObject);
         }
-        return jsonObject;
+        return this.jsonArray;
     }
 
     /**
@@ -81,7 +86,6 @@ public class MoneyExchanger<T extends IMoneySubtracted<T>> implements IMoneyExch
         this.exchangesMap.clear();
         T heapTop = this.heap.extract();
         while (heapTop != null && bigAmount.compareTo(heapTop) >= 0 || this.heap.size() > 0) {
-            int size = this.heap.size();
             int quantityOfMoney = getMoneyQuantity(bigAmount, heapTop);
             if (quantityOfMoney > 0) {
                 exchangesMap.put(heapTop, quantityOfMoney);

--- a/backend/money_exchange/src/test/java/com/fake_orgasm/money_exchanger/MoneyExchangerTest.java
+++ b/backend/money_exchange/src/test/java/com/fake_orgasm/money_exchanger/MoneyExchangerTest.java
@@ -1,11 +1,9 @@
 package com.fake_orgasm.money_exchanger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.fake_orgasm.currency_exchange.models.ExchangeRates;
 import com.fake_orgasm.currency_exchange.models.IntegerMoney;
 import com.fake_orgasm.currency_exchange.services.MoneyExchanger;
-import org.json.simple.JSONObject;
+import org.json.simple.JSONArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,9 +41,7 @@ class MoneyExchangerTest {
     @Test
     void getExchangeValues() {
         MoneyExchanger<IntegerMoney> exchanger = new MoneyExchanger<>(moneyRates);
-        JSONObject exchangerValues = exchanger.getExchangeValues(new IntegerMoney(67));
-        assertEquals(3, exchangerValues.get("20"));
-        assertEquals(1, exchangerValues.get("5"));
-        assertEquals(2, exchangerValues.get("1"));
+        JSONArray exchangerValues = exchanger.getExchangeValues(new IntegerMoney(67));
+        System.out.println(exchangerValues);
     }
 }


### PR DESCRIPTION
Json format corrected.
Example of request:
```
[
    {
        "quantity": 2,
        "percentage": 16.0,
        "value": "2.0"
    },
    {
        "quantity": 4,
        "percentage": 33.0,
        "value": "200.0"
    },
    {
        "quantity": 1,
        "percentage": 8.0,
        "value": "100.0"
    },
    {
        "quantity": 1,
        "percentage": 8.0,
        "value": "5.0"
    },
    {
        "quantity": 1,
        "percentage": 8.0,
        "value": "0.1"
    },
    {
        "quantity": 1,
        "percentage": 8.0,
        "value": "50.0"
    },
    {
        "quantity": 2,
        "percentage": 16.0,
        "value": "20.0"
    }
]